### PR TITLE
Make barrier_gradient_batch faster and memory efficient.

### DIFF
--- a/neural_network_lyapunov/barrier.py
+++ b/neural_network_lyapunov/barrier.py
@@ -244,16 +244,11 @@ class Barrier:
         c = 100.
         x_requires_grad = x.requires_grad
         x.requires_grad = True
-        dhdx = torch.zeros_like(x, dtype=x.dtype)
         h = self.barrier_value(x, x_star, c, inf_norm_term=inf_norm_term)
-        for i in range(x.shape[0]):
-            grd = torch.zeros_like(h, dtype=x.dtype)
-            grd[i] = 1
-            dhdx[i, :] = torch.autograd.grad(
-                outputs=h,
-                inputs=x,
-                grad_outputs=grd,
-                retain_graph=True,
-                create_graph=create_graph)[0][i, :]
+        dhdx = torch.autograd.grad(outputs=h,
+                                   inputs=x,
+                                   grad_outputs=torch.ones_like(h),
+                                   create_graph=create_graph,
+                                   retain_graph=True)[0]
         x.requires_grad = x_requires_grad
         return dhdx

--- a/neural_network_lyapunov/nominal_controller.py
+++ b/neural_network_lyapunov/nominal_controller.py
@@ -8,6 +8,7 @@ require the nominal controller and the CLF/CBF to satisfy the Lyapunov/barrier
 condition on all of the inifinitely many states.
 We need to compute the gradient of the controller.
 """
+import neural_network_lyapunov.utils as utils
 import torch
 
 
@@ -29,6 +30,9 @@ class NominalController:
         """
         Return all the trainable parameters of the controller.
         """
+        raise NotImplementedError
+
+    def to_save_data(self):
         raise NotImplementedError
 
 
@@ -66,3 +70,15 @@ class NominalNNController(NominalController):
 
     def parameters(self):
         return self.network.parameters()
+
+    def to_save_data(self):
+        linear_layer_width, negative_slope, bias = \
+            utils.extract_relu_structure(self.network)
+        return {
+            "linear_layer_width": linear_layer_width,
+            "negative_slope": negative_slope,
+            "bias": bias,
+            "state_dict": self.network.state_dict(),
+            "x_star": self.x_star,
+            "u_star": self.u_star
+        }

--- a/neural_network_lyapunov/train_barrier.py
+++ b/neural_network_lyapunov/train_barrier.py
@@ -451,16 +451,16 @@ class TrainBarrier:
         """
         sample_actions = self.nominal_control_option.controller.output(
             self.nominal_control_option.sample_states)
-        sample_val = -self.epsilon * self.barrier_system.barrier_value(
-            self.nominal_control_option.sample_states,
-            self.x_star,
-            self.c,
-            inf_norm_term=self.inf_norm_term
-        ) - self.barrier_system.barrier_derivative_given_action_batch(
+        hdot = self.barrier_system.barrier_derivative_given_action_batch(
             self.nominal_control_option.sample_states,
             sample_actions,
             create_graph=True,
             inf_norm_term=self.inf_norm_term)
+        sample_val = -self.epsilon * self.barrier_system.barrier_value(
+            self.nominal_control_option.sample_states,
+            self.x_star,
+            self.c,
+            inf_norm_term=self.inf_norm_term) - hdot
         if self.nominal_control_option.norm == "mean":
             return self.nominal_control_option.weight * \
                 torch.nn.HingeEmbeddingLoss(

--- a/neural_network_lyapunov/utils.py
+++ b/neural_network_lyapunov/utils.py
@@ -1162,13 +1162,16 @@ def save_controller_model(controller_relu, x_lo, x_up, u_lo, u_up, file_path):
 
 
 def save_control_barrier_function(barrier_relu, x_star, c, epsilon, x_lo, x_up,
-                                  u_lo, u_up, inf_norm_term, save_path):
+                                  u_lo, u_up, inf_norm_term, nominal_control,
+                                  save_path):
     linear_layer_width, negative_slope, bias = extract_relu_structure(
         barrier_relu)
     inf_norm_data = None if inf_norm_term is None else {
         "R": inf_norm_term.R,
         "p": inf_norm_term.p
     }
+    nominal_control_data = None if nominal_control is None else\
+        nominal_control.to_save_data()
     torch.save(
         {
             "linear_layer_width": linear_layer_width,
@@ -1182,7 +1185,8 @@ def save_control_barrier_function(barrier_relu, x_star, c, epsilon, x_lo, x_up,
             "x_up": x_up,
             "u_lo": u_lo,
             "u_up": u_up,
-            "inf_norm_term": inf_norm_data
+            "inf_norm_term": inf_norm_data,
+            "nominal_control": nominal_control_data
         }, save_path)
 
 


### PR DESCRIPTION
Previously it takes 100GB of memory for 10,000 state samples and 40s. Now it takes 11s for 30,000 state samples.
Remove the for loop inside _barrier_gradient_batch